### PR TITLE
Fix examples for multiplication and division

### DIFF
--- a/syntax/expressions.md
+++ b/syntax/expressions.md
@@ -140,7 +140,7 @@ Jtwig comes with several built in binary operators. Below, one will describe the
             </td>
             <td style="text-align: center;">5</td>
             <td>Multiplies two values.</td>
-            <td><code>2.2 * 2.2</code> outputs <code>4.4</code>
+            <td><code>5.0 * 2.5</code> outputs <code>12.5</code>
             </td>
         </tr>
         <tr>
@@ -149,7 +149,7 @@ Jtwig comes with several built in binary operators. Below, one will describe the
             </td>
             <td style="text-align: center;">5</td>
             <td>Multiplies the integer part of two values.</td>
-            <td><code>2.2 * 2.2</code> outputs <code>4</code>
+            <td><code>5.0 ** 2.5</code> outputs <code>10</code>
             </td>
         </tr>
         <tr>
@@ -158,7 +158,7 @@ Jtwig comes with several built in binary operators. Below, one will describe the
             </td>
             <td style="text-align: center;">5</td>
             <td>Divides two values.</td>
-            <td><code>2.2 * 2.2</code> outputs <code>1.1</code>
+            <td><code>5.0 / 2.5</code> outputs <code>2</code>
             </td>
         </tr>
         <tr>
@@ -167,7 +167,7 @@ Jtwig comes with several built in binary operators. Below, one will describe the
             </td>
             <td style="text-align: center;">5</td>
             <td>Divides the integer part of two values.</td>
-            <td><code>2.2 * 2.2</code> outputs <code>1</code>
+            <td><code>5.0 // 2.5</code> outputs <code>2.5</code>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
I've avoided using 2.x ** 2.x == 4.x in the examples because readers might mistake `**` for exponentiation. `2 ** 2 == 4` happens to be true in many programming languages, but for other reasons.

And I think it is clearer now that ** and // truncate the *operands*, not the *result*. This is different from e.g. Pascal's `div` operator for integer division.